### PR TITLE
Keep enclosing classes to prevent warnings.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,12 @@ forking the repository and sending a pull request.
 
 When submitting code, please make every effort to follow existing conventions
 and style in order to keep the code as readable as possible. Please also make
-sure your code compiles by running `./gradlew clean build`.
+sure your code compiles by running:
+
+``` shell
+git submodule sync && git submodule update --init --recursive
+mvn clean install
+```
 
 Before your code can be accepted into the project you must also sign the
 [Individual Contributor License Agreement (CLA)][1].

--- a/pom.xml
+++ b/pom.xml
@@ -167,13 +167,34 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>net.sf.proguard</groupId>
+            <artifactId>proguard-base</artifactId>
+            <version>5.2.1</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
         <configuration>
+          <proguardVersion>5.2.1</proguardVersion>
           <obfuscate>false</obfuscate>
           <options>
             <option>-allowaccessmodification</option>
             <option>-keep class com.squareup.haha.perflib.** { *; }</option>
+            <option>-keep class com.squareup.haha.trove.THashMap { *; }</option>
             <option>-dontwarn javax.annotation.**</option>
             <option>-optimizations !code/allocation/variable</option>
+            <!-- Proguard removes Iterables but includes its inner class, Iterables$2. It then
+                 removes the EnclosingMethod attribute from Iterables$2, presumably because it
+                 references a non-existent class. This causes warnings for HAHA's dependents like:
+
+                     "Ignoring InnerClasses attribute for an anonymous inner class [...] that
+                     doesn't come with an associated EnclosingMethod attribute."
+
+                 Keeping Iterables prevents Proguard from removing the EnclosingMethod attribute.
+                 See https://sourceforge.net/p/proguard/discussion/182456/thread/6920e89e.
+                 -->
+            <option>-keepnames class com.squareup.haha.guava.collect.Iterables</option>
           </options>
           <libs>
             <lib>${java.home}/lib/rt.jar</lib>


### PR DESCRIPTION
This is one option. Adding -dontoptimize also works but increases the jar size by 28K.

I don't know the cause of the issue but I found someone else has been looking into it: https://sourceforge.net/p/proguard/discussion/182456/thread/6920e89e/. Maybe they will get an answer.

Any way to test this? I built leak canary and ran its tests. 